### PR TITLE
Add RSpec integration for single test N+1 TODO update

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -52,6 +52,40 @@ bundle exec rake prosopite_todo:list
 bundle exec rake prosopite_todo:clean
 ```
 
+### RSpec 統合 - 単一テストから N+1 を追加
+
+単一のテストを実行して、検出された N+1 クエリを TODO ファイルに追加したい場合、RSpec 統合ヘルパーを使用できます。
+
+**セットアップ:**
+
+`spec/rails_helper.rb`（または `spec/spec_helper.rb`）に以下を追加してください：
+
+```ruby
+require 'prosopite_todo/rspec'
+```
+
+**使い方:**
+
+`PROSOPITE_TODO_UPDATE` 環境変数を指定してテストを実行します：
+
+```bash
+# 単一のテストファイルを実行
+PROSOPITE_TODO_UPDATE=1 bundle exec rspec spec/models/user_spec.rb
+
+# 特定の行のテストを実行
+PROSOPITE_TODO_UPDATE=1 bundle exec rspec spec/models/user_spec.rb:42
+
+# パターンに一致するテストを実行
+PROSOPITE_TODO_UPDATE=1 bundle exec rspec spec/models/ --pattern "*_spec.rb"
+```
+
+これにより：
+1. 指定されたテストが実行されます
+2. Prosopite 経由で N+1 クエリが自動的に検出されます
+3. テストスイート完了後、新しい N+1 検出が `.prosopite_todo.yaml` に追加されます
+
+これは、他のテストに影響を与えずに、発見した既知の N+1 クエリを TODO ファイルに段階的に追加する際に便利です。
+
 ## 仕組み
 
 1. **フィンガープリント**: 各 N+1 クエリは SQL クエリとコールスタックの位置に基づくフィンガープリントで識別されます

--- a/README.md
+++ b/README.md
@@ -52,6 +52,40 @@ To remove entries that are no longer detected (i.e., the N+1 has been fixed):
 bundle exec rake prosopite_todo:clean
 ```
 
+### RSpec Integration - Adding N+1 from a single test
+
+When you want to run a single test and add its detected N+1 queries to the TODO file, you can use the RSpec integration helper.
+
+**Setup:**
+
+Add to your `spec/rails_helper.rb` (or `spec/spec_helper.rb`):
+
+```ruby
+require 'prosopite_todo/rspec'
+```
+
+**Usage:**
+
+Run your test with the `PROSOPITE_TODO_UPDATE` environment variable:
+
+```bash
+# Run a single test file
+PROSOPITE_TODO_UPDATE=1 bundle exec rspec spec/models/user_spec.rb
+
+# Run a specific test line
+PROSOPITE_TODO_UPDATE=1 bundle exec rspec spec/models/user_spec.rb:42
+
+# Run tests matching a pattern
+PROSOPITE_TODO_UPDATE=1 bundle exec rspec spec/models/ --pattern "*_spec.rb"
+```
+
+This will:
+1. Run the specified test(s)
+2. Automatically detect N+1 queries via Prosopite
+3. Add any new N+1 detections to `.prosopite_todo.yaml` after the test suite completes
+
+This is useful for incrementally adding known N+1 queries to your TODO file as you discover them, without affecting other tests.
+
 ## How it works
 
 1. **Fingerprinting**: Each N+1 query is identified by a fingerprint based on the SQL query and its call stack location

--- a/lib/prosopite_todo.rb
+++ b/lib/prosopite_todo.rb
@@ -32,5 +32,23 @@ module ProsopiteTodo
     def clear_pending_notifications
       @pending_notifications = {}
     end
+
+    # Update TODO file with pending notifications (adds new entries without removing existing ones)
+    # Returns the number of new entries added
+    def update_todo!
+      todo_file = TodoFile.new(todo_file_path)
+      initial_count = todo_file.entries.length
+
+      Scanner.record_notifications(pending_notifications, todo_file)
+      todo_file.save
+
+      new_count = todo_file.entries.length - initial_count
+
+      if new_count.positive?
+        warn "[ProsopiteTodo] Added #{new_count} new N+1 entries to #{todo_file.path}"
+      end
+
+      new_count
+    end
   end
 end

--- a/lib/prosopite_todo/railtie.rb
+++ b/lib/prosopite_todo/railtie.rb
@@ -28,8 +28,10 @@ module ProsopiteTodo
           # Filter out ignored notifications
           filtered = ProsopiteTodo::Scanner.filter_notifications(notifications, todo_file)
 
-          # Store original notifications for todo generation
-          ProsopiteTodo.pending_notifications = notifications
+          # Accumulate notifications for todo generation (supports multiple test runs)
+          notifications.each do |query, locations|
+            ProsopiteTodo.add_pending_notification(query: query, locations: locations)
+          end
 
           # Call original callback with filtered notifications if it exists
           original_callback&.call(filtered)

--- a/lib/prosopite_todo/rspec.rb
+++ b/lib/prosopite_todo/rspec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "prosopite_todo"
+
+module ProsopiteTodo
+  # RSpec integration helper for adding N+1 detections to TODO file
+  #
+  # Usage in spec/rails_helper.rb:
+  #   require 'prosopite_todo/rspec'
+  #
+  # Then run:
+  #   PROSOPITE_TODO_UPDATE=1 bundle exec rspec spec/models/user_spec.rb
+  #
+  module RSpec
+    class << self
+      def setup
+        return unless enabled?
+
+        ::RSpec.configure do |config|
+          config.after(:suite) do
+            ProsopiteTodo.update_todo!
+          end
+        end
+      end
+
+      def enabled?
+        %w[1 true yes].include?(ENV.fetch("PROSOPITE_TODO_UPDATE", nil)&.downcase)
+      end
+    end
+  end
+end
+
+# Auto-setup when required
+ProsopiteTodo::RSpec.setup

--- a/spec/prosopite_todo/rspec_spec.rb
+++ b/spec/prosopite_todo/rspec_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "prosopite_todo/rspec"
+
+RSpec.describe ProsopiteTodo::RSpec do
+  describe ".enabled?" do
+    after do
+      ENV.delete("PROSOPITE_TODO_UPDATE")
+    end
+
+    it "returns false when PROSOPITE_TODO_UPDATE is not set" do
+      ENV.delete("PROSOPITE_TODO_UPDATE")
+      expect(described_class.enabled?).to be false
+    end
+
+    it "returns true when PROSOPITE_TODO_UPDATE is '1'" do
+      ENV["PROSOPITE_TODO_UPDATE"] = "1"
+      expect(described_class.enabled?).to be true
+    end
+
+    it "returns true when PROSOPITE_TODO_UPDATE is 'true'" do
+      ENV["PROSOPITE_TODO_UPDATE"] = "true"
+      expect(described_class.enabled?).to be true
+    end
+
+    it "returns true when PROSOPITE_TODO_UPDATE is 'yes'" do
+      ENV["PROSOPITE_TODO_UPDATE"] = "yes"
+      expect(described_class.enabled?).to be true
+    end
+
+    it "returns true when PROSOPITE_TODO_UPDATE is 'TRUE' (case insensitive)" do
+      ENV["PROSOPITE_TODO_UPDATE"] = "TRUE"
+      expect(described_class.enabled?).to be true
+    end
+
+    it "returns false when PROSOPITE_TODO_UPDATE is '0'" do
+      ENV["PROSOPITE_TODO_UPDATE"] = "0"
+      expect(described_class.enabled?).to be false
+    end
+
+    it "returns false when PROSOPITE_TODO_UPDATE is 'false'" do
+      ENV["PROSOPITE_TODO_UPDATE"] = "false"
+      expect(described_class.enabled?).to be false
+    end
+  end
+end

--- a/spec/prosopite_todo_spec.rb
+++ b/spec/prosopite_todo_spec.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "tempfile"
+require "fileutils"
+
 RSpec.describe ProsopiteTodo do
   it "has a version number" do
     expect(ProsopiteTodo::VERSION).not_to be_nil
@@ -33,6 +36,82 @@ RSpec.describe ProsopiteTodo do
         locations: [["app/models/user.rb:10"]]
       )
       expect(ProsopiteTodo.pending_notifications).to have_key("SELECT * FROM users")
+    end
+  end
+
+  describe ".update_todo!" do
+    let(:temp_dir) { Dir.mktmpdir }
+    let(:todo_path) { File.join(temp_dir, ".prosopite_todo.yaml") }
+
+    before do
+      ProsopiteTodo.todo_file_path = todo_path
+    end
+
+    after do
+      ProsopiteTodo.clear_pending_notifications
+      ProsopiteTodo.todo_file_path = nil
+      FileUtils.rm_rf(temp_dir)
+    end
+
+    it "creates TODO file with pending notifications" do
+      ProsopiteTodo.add_pending_notification(
+        query: "SELECT * FROM users WHERE id = ?",
+        locations: [["app/models/user.rb:10", "app/controllers/users_controller.rb:5"]]
+      )
+
+      expect { ProsopiteTodo.update_todo! }.to output(/Added 1 new N\+1 entries/).to_stderr
+
+      todo_file = ProsopiteTodo::TodoFile.new(todo_path)
+      expect(todo_file.entries.length).to eq(1)
+      expect(todo_file.entries.first["query"]).to eq("SELECT * FROM users WHERE id = ?")
+    end
+
+    it "adds new entries without removing existing ones" do
+      # Create initial entry
+      ProsopiteTodo.add_pending_notification(
+        query: "SELECT * FROM users WHERE id = ?",
+        locations: [["app/models/user.rb:10"]]
+      )
+      ProsopiteTodo.update_todo!
+      ProsopiteTodo.clear_pending_notifications
+
+      # Add another entry
+      ProsopiteTodo.add_pending_notification(
+        query: "SELECT * FROM posts WHERE user_id = ?",
+        locations: [["app/models/post.rb:20"]]
+      )
+      ProsopiteTodo.update_todo!
+
+      todo_file = ProsopiteTodo::TodoFile.new(todo_path)
+      expect(todo_file.entries.length).to eq(2)
+    end
+
+    it "returns the number of new entries added" do
+      ProsopiteTodo.add_pending_notification(
+        query: "SELECT * FROM users WHERE id = ?",
+        locations: [["app/models/user.rb:10"]]
+      )
+
+      expect(ProsopiteTodo.update_todo!).to eq(1)
+    end
+
+    it "does not add duplicate entries" do
+      ProsopiteTodo.add_pending_notification(
+        query: "SELECT * FROM users WHERE id = ?",
+        locations: [["app/models/user.rb:10"]]
+      )
+      ProsopiteTodo.update_todo!
+
+      # Add same notification again
+      ProsopiteTodo.add_pending_notification(
+        query: "SELECT * FROM users WHERE id = ?",
+        locations: [["app/models/user.rb:10"]]
+      )
+      new_count = ProsopiteTodo.update_todo!
+
+      expect(new_count).to eq(0)
+      todo_file = ProsopiteTodo::TodoFile.new(todo_path)
+      expect(todo_file.entries.length).to eq(1)
     end
   end
 end


### PR DESCRIPTION
## Summary

- Add `ProsopiteTodo::RSpec` helper module that automatically adds N+1 detections to TODO file after test suite completion
- Add `ProsopiteTodo.update_todo!` method for programmatic TODO updates  
- Change Railtie to accumulate notifications across multiple tests instead of overwriting
- Add `PROSOPITE_TODO_UPDATE` environment variable to enable the feature

## Usage

```ruby
# spec/rails_helper.rb
require 'prosopite_todo/rspec'
```

```bash
# Run a single test and add detected N+1 to TODO
PROSOPITE_TODO_UPDATE=1 bundle exec rspec spec/models/user_spec.rb:42
```

## Test plan

- [x] Add unit tests for `ProsopiteTodo.update_todo!` method
- [x] Add unit tests for `ProsopiteTodo::RSpec.enabled?` method
- [x] Verify all existing tests still pass
- [x] Update README.md with usage documentation
- [x] Update README.ja.md with Japanese documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)