### PR TITLE
Add comprehensive test coverage for edge cases and error handling

### DIFF
--- a/spec/prosopite_todo/railtie_spec.rb
+++ b/spec/prosopite_todo/railtie_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "tempfile"
+require "fileutils"
 
 RSpec.describe ProsopiteTodo::Railtie do
   it "is a Rails::Railtie" do
@@ -9,5 +11,154 @@ RSpec.describe ProsopiteTodo::Railtie do
 
   it "has rake tasks" do
     expect(described_class.rake_tasks).not_to be_empty
+  end
+
+  describe ".setup_prosopite_integration" do
+    let(:tmp_dir) { Dir.mktmpdir }
+    let(:todo_file_path) { File.join(tmp_dir, ".prosopite_todo.yaml") }
+
+    before do
+      allow(ProsopiteTodo::TodoFile).to receive(:new).and_return(
+        ProsopiteTodo::TodoFile.new(todo_file_path)
+      )
+    end
+
+    after do
+      FileUtils.rm_rf(tmp_dir)
+      # Reset Prosopite state
+      if defined?(Prosopite)
+        Prosopite.instance_variable_set(:@finish_callback, nil)
+      end
+      ProsopiteTodo.clear_pending_notifications
+    end
+
+    context "when Prosopite is not defined" do
+      before do
+        hide_const("Prosopite") if defined?(Prosopite)
+      end
+
+      it "does not raise error" do
+        expect { described_class.setup_prosopite_integration }.not_to raise_error
+      end
+
+      it "returns nil" do
+        result = described_class.setup_prosopite_integration
+        expect(result).to be_nil
+      end
+    end
+
+    context "when Prosopite is defined" do
+      before do
+        stub_const("Prosopite", Class.new do
+          class << self
+            attr_accessor :finish_callback
+
+            def instance_variable_get(name)
+              @finish_callback if name == :@finish_callback
+            end
+          end
+        end)
+      end
+
+      it "sets finish_callback on Prosopite" do
+        described_class.setup_prosopite_integration
+        expect(Prosopite.finish_callback).to be_a(Proc)
+      end
+
+      it "filters notifications through Scanner" do
+        described_class.setup_prosopite_integration
+
+        notifications = {
+          "SELECT * FROM users" => [["app/models/user.rb:10"]]
+        }
+
+        result = Prosopite.finish_callback.call(notifications)
+
+        # Should return filtered notifications (all in this case since nothing is ignored)
+        expect(result).to eq(notifications)
+      end
+
+      it "accumulates notifications in pending_notifications" do
+        described_class.setup_prosopite_integration
+
+        notifications = {
+          "SELECT * FROM users" => [["app/models/user.rb:10"]]
+        }
+
+        Prosopite.finish_callback.call(notifications)
+
+        expect(ProsopiteTodo.pending_notifications).to have_key("SELECT * FROM users")
+      end
+
+      context "when original callback exists" do
+        it "preserves and calls original callback" do
+          callback_called = false
+          original_callback = proc do |filtered|
+            callback_called = true
+            expect(filtered).to be_a(Hash)
+          end
+
+          Prosopite.finish_callback = original_callback
+
+          described_class.setup_prosopite_integration
+
+          notifications = {
+            "SELECT * FROM users" => [["app/models/user.rb:10"]]
+          }
+
+          Prosopite.finish_callback.call(notifications)
+
+          expect(callback_called).to be true
+        end
+
+        it "passes filtered notifications to original callback" do
+          received_notifications = nil
+          original_callback = proc { |filtered| received_notifications = filtered }
+
+          Prosopite.finish_callback = original_callback
+
+          # Create a todo file entry to filter out
+          todo_file = ProsopiteTodo::TodoFile.new(todo_file_path)
+          fp = ProsopiteTodo::Scanner.fingerprint(
+            query: "SELECT * FROM users",
+            location: ["app/models/user.rb:10"]
+          )
+          todo_file.add_entry(
+            fingerprint: fp,
+            query: "SELECT * FROM users",
+            location: "app/models/user.rb:10"
+          )
+          todo_file.save
+
+          described_class.setup_prosopite_integration
+
+          notifications = {
+            "SELECT * FROM users" => [["app/models/user.rb:10"]],
+            "SELECT * FROM posts" => [["app/models/post.rb:20"]]
+          }
+
+          Prosopite.finish_callback.call(notifications)
+
+          # Original callback should only receive non-ignored notifications
+          expect(received_notifications.keys).to eq(["SELECT * FROM posts"])
+        end
+      end
+
+      context "when original callback is nil" do
+        before do
+          Prosopite.finish_callback = nil
+        end
+
+        it "does not raise error" do
+          described_class.setup_prosopite_integration
+
+          notifications = {
+            "SELECT * FROM users" => [["app/models/user.rb:10"]]
+          }
+
+          expect { Prosopite.finish_callback.call(notifications) }.not_to raise_error
+        end
+      end
+    end
   end
 end

--- a/spec/prosopite_todo/rspec_spec.rb
+++ b/spec/prosopite_todo/rspec_spec.rb
@@ -42,5 +42,65 @@ RSpec.describe ProsopiteTodo::RSpec do
       ENV["PROSOPITE_TODO_UPDATE"] = "false"
       expect(described_class.enabled?).to be false
     end
+
+    it "returns true when PROSOPITE_TODO_UPDATE is 'YES' (case insensitive)" do
+      ENV["PROSOPITE_TODO_UPDATE"] = "YES"
+      expect(described_class.enabled?).to be true
+    end
+
+    it "returns false when PROSOPITE_TODO_UPDATE is empty string" do
+      ENV["PROSOPITE_TODO_UPDATE"] = ""
+      expect(described_class.enabled?).to be false
+    end
+
+    it "returns false when PROSOPITE_TODO_UPDATE is whitespace" do
+      ENV["PROSOPITE_TODO_UPDATE"] = "   "
+      expect(described_class.enabled?).to be false
+    end
+
+    it "returns false when PROSOPITE_TODO_UPDATE is 'no'" do
+      ENV["PROSOPITE_TODO_UPDATE"] = "no"
+      expect(described_class.enabled?).to be false
+    end
+
+    it "returns false for unexpected values" do
+      ENV["PROSOPITE_TODO_UPDATE"] = "enabled"
+      expect(described_class.enabled?).to be false
+    end
+  end
+
+  describe ".setup" do
+    after do
+      ENV.delete("PROSOPITE_TODO_UPDATE")
+    end
+
+    context "when not enabled" do
+      before do
+        ENV.delete("PROSOPITE_TODO_UPDATE")
+      end
+
+      it "does not configure RSpec" do
+        # Create a mock RSpec configuration
+        mock_config = double("RSpec::Configuration")
+
+        # setup should not call RSpec.configure when disabled
+        expect(::RSpec).not_to receive(:configure)
+
+        described_class.setup
+      end
+    end
+
+    context "when enabled" do
+      before do
+        ENV["PROSOPITE_TODO_UPDATE"] = "1"
+      end
+
+      it "configures RSpec with after(:suite) hook" do
+        # We can't easily test the actual RSpec configuration without running
+        # a real test suite, but we can verify the method doesn't raise errors
+        # The actual integration is tested by verifying the auto-setup works
+        expect { described_class.setup }.not_to raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Add YAML error handling tests (invalid YAML, disallowed classes, empty files)
- Add file system error tests (read-only directories, permission errors)  
- Add fingerprint edge case tests (empty strings, unicode, long queries, nil inputs)
- Add Railtie integration tests (Prosopite callback setup, callback preservation)
- Add RSpec integration tests (environment variable handling, setup behavior)
- Add Scanner edge case tests (empty notifications, multiple locations, call stack normalization)
- Add main module tests (pending notifications merging, update_todo! edge cases)

Test count increased from ~60 to 107 examples.

## Test Coverage Added

### TodoFile (todo_file_spec.rb)
- Empty file handling
- Whitespace-only file handling
- Invalid YAML syntax (Psych::SyntaxError)
- YAML with disallowed classes (Psych::DisallowedClass)
- YAML null value handling
- Read-only directory errors (Errno::EACCES)
- Read-only file errors (Errno::EACCES)
- Nested directory creation

### Scanner (scanner_spec.rb)
- 16-character hexadecimal fingerprint format
- Empty query string handling
- Empty location array handling
- String location (instead of array)
- Nil location handling
- Very long query strings
- Unicode characters in queries
- Special characters (JSON) in queries
- Newlines in queries
- Multiple locations (call stack)
- Location order sensitivity
- Empty notifications hash
- Empty locations array in notifications
- Multiple locations per query
- Call stack normalization (joined with " -> ")
- Duplicate notification handling

### Railtie (railtie_spec.rb)
- Prosopite not defined scenario
- finish_callback setup
- Notification filtering through Scanner
- Pending notifications accumulation
- Original callback preservation
- Filtered notifications passed to original callback
- Nil original callback handling

### RSpec Integration (rspec_spec.rb)
- YES (uppercase) environment variable
- Empty string environment variable
- Whitespace environment variable
- "no" value handling
- Unexpected values (like "enabled")
- .setup method behavior when disabled
- .setup method behavior when enabled

### Main Module (prosopite_todo_spec.rb)
- Locations merging for same query
- Single location handling (not wrapped in array)
- clear_pending_notifications behavior
- update_todo! with no pending notifications
- update_todo! no output when no new entries
- Multiple locations for same query
- Call stack locations handling

## Test plan
- [x] All 107 tests pass
- [x] No breaking changes to existing functionality
- [x] Edge cases properly handled

🤖 Generated with [Claude Code](https://claude.com/claude-code)