### PR TITLE
Fix installation instructions for GitHub-only gem

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -7,7 +7,7 @@
 Gemfile に以下を追加してください：
 
 ```ruby
-gem 'prosopite_todo'
+gem 'prosopite_todo', github: 's4na/prosopite_todo'
 ```
 
 その後、以下を実行します：

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A RuboCop-like TODO file for [Prosopite](https://github.com/charkost/prosopite) 
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'prosopite_todo'
+gem 'prosopite_todo', github: 's4na/prosopite_todo'
 ```
 
 And then execute:


### PR DESCRIPTION
## Summary
- Update README.md and README.ja.md to use `github: 's4na/prosopite_todo'` syntax
- The gem is only published on GitHub, not RubyGems

🤖 Generated with [Claude Code](https://claude.com/claude-code)