### PR TITLE
docs: Add Prosopite.scan configuration to RSpec integration section

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,53 @@ Add to your `spec/rails_helper.rb` (or `spec/spec_helper.rb`):
 require 'prosopite_todo/rspec'
 ```
 
+**Important:** The `prosopite_todo/rspec` helper only saves detected N+1 queries to the TODO file after the test suite completes. You must also enable `Prosopite.scan` to actually detect N+1 queries. Here are two approaches:
+
+**Option 1: Enable scanning for all tests when updating TODO (recommended)**
+
+```ruby
+# spec/rails_helper.rb
+require 'prosopite_todo/rspec'
+
+RSpec.configure do |config|
+  config.around(:example) do |example|
+    if ENV['PROSOPITE_TODO_UPDATE']
+      original_raise = Prosopite.raise?
+      Prosopite.raise = false
+      Prosopite.scan do
+        example.run
+      end
+      Prosopite.raise = original_raise
+    else
+      example.run
+    end
+  end
+end
+```
+
+**Option 2: Enable scanning for specific tests**
+
+```ruby
+# spec/rails_helper.rb
+require 'prosopite_todo/rspec'
+
+RSpec.configure do |config|
+  config.around(:example, prosopite_scan: true) do |example|
+    Prosopite.scan do
+      example.run
+    end
+  end
+end
+```
+
+Then add the `prosopite_scan: true` tag to individual tests:
+
+```ruby
+it "loads user posts", prosopite_scan: true do
+  # your test code
+end
+```
+
 **Usage:**
 
 Run your test with the `PROSOPITE_TODO_UPDATE` environment variable:


### PR DESCRIPTION
## Summary

- Added documentation explaining that `Prosopite.scan` must be enabled separately to detect N+1 queries
- Added two configuration options for enabling Prosopite scanning in RSpec tests:
  - Option 1: Enable scanning for all tests when `PROSOPITE_TODO_UPDATE` environment variable is set (recommended)
  - Option 2: Enable scanning for specific tests using the `prosopite_scan: true` tag
- Updated both README.md and README.ja.md

## Test plan

- [ ] Verify the documentation is clear and accurate
- [ ] Confirm the code examples work as expected

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)