### PR TITLE
docs: Add cross-language links between README files

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,5 +1,7 @@
 # ProsopiteTodo
 
+[English](./README.md)
+
 > **注意**: この gem は実験的なものです。動作確認がまだ十分に取れていません。十分な動作確認が取れた後、RubyGems に公開する予定です。
 
 [Prosopite](https://github.com/charkost/prosopite) N+1検出のための RuboCop ライクな TODO ファイル機能を提供する gem です。`.prosopite_todo.yaml` を使って既知の N+1 クエリを無視できます。

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ProsopiteTodo
 
+[日本語版 (Japanese)](./README.ja.md)
+
 > **Note**: This gem is experimental. Testing is not yet complete. Once sufficient testing has been done, we plan to publish it to RubyGems.
 
 A RuboCop-like TODO file for [Prosopite](https://github.com/charkost/prosopite) N+1 detection. This gem allows you to ignore known N+1 queries via `.prosopite_todo.yaml`, similar to RuboCop's TODO functionality.


### PR DESCRIPTION
## Summary
- Add link to Japanese README (README.ja.md) at the top of README.md
- Add link to English README (README.md) at the top of README.ja.md
- Enables easy navigation between language versions

## Test plan
- [ ] Verify the link in README.md navigates to README.ja.md correctly
- [ ] Verify the link in README.ja.md navigates to README.md correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)