### PR TITLE
feat: Add prosopite_todo:run task to run recorded tests

### DIFF
--- a/lib/prosopite_todo/task_helpers.rb
+++ b/lib/prosopite_todo/task_helpers.rb
@@ -93,17 +93,21 @@ module ProsopiteTodo
 
         if test_locations.empty?
           output.puts "No test locations found in #{todo_file.path}"
-          return
+          return false
         end
 
         output.puts "Running #{test_locations.size} test(s) from #{todo_file.path}..."
-        test_files = test_locations.to_a.join(" ")
+        test_files = test_locations.to_a
+        output.puts "Executing: PROSOPITE_TODO_UPDATE=1 bundle exec rspec #{test_files.join(' ')}"
 
-        # Execute rspec with PROSOPITE_TODO_UPDATE=1 to auto-update the TODO file
-        command = "PROSOPITE_TODO_UPDATE=1 bundle exec rspec #{test_files}"
-        output.puts "Executing: #{command}"
+        # Use array form of system to avoid shell injection vulnerabilities
+        success = system({ "PROSOPITE_TODO_UPDATE" => "1" }, "bundle", "exec", "rspec", *test_files)
 
-        system(command)
+        unless success
+          output.puts "Tests failed (exit code: #{$CHILD_STATUS&.exitstatus})"
+        end
+
+        success
       end
     end
   end

--- a/lib/prosopite_todo/task_helpers.rb
+++ b/lib/prosopite_todo/task_helpers.rb
@@ -86,6 +86,25 @@ module ProsopiteTodo
 
         output.puts "Cleaned #{todo_file.path}: removed #{removed_count} locations, #{todo_file.entries.length} entries remaining"
       end
+
+      def run(output: $stdout)
+        todo_file = ProsopiteTodo::TodoFile.new(ProsopiteTodo.todo_file_path)
+        test_locations = todo_file.test_locations
+
+        if test_locations.empty?
+          output.puts "No test locations found in #{todo_file.path}"
+          return
+        end
+
+        output.puts "Running #{test_locations.size} test(s) from #{todo_file.path}..."
+        test_files = test_locations.to_a.join(" ")
+
+        # Execute rspec with PROSOPITE_TODO_UPDATE=1 to auto-update the TODO file
+        command = "PROSOPITE_TODO_UPDATE=1 bundle exec rspec #{test_files}"
+        output.puts "Executing: #{command}"
+
+        system(command)
+      end
     end
   end
 end

--- a/lib/prosopite_todo/tasks.rb
+++ b/lib/prosopite_todo/tasks.rb
@@ -22,4 +22,9 @@ namespace :prosopite_todo do
   task :clean do
     ProsopiteTodo::TaskHelpers.clean
   end
+
+  desc "Run only tests recorded in .prosopite_todo.yaml and update the file"
+  task :run do
+    ProsopiteTodo::TaskHelpers.run
+  end
 end


### PR DESCRIPTION
## Related Issue
Closes #27

## User Request / AI Reasoning
- **要望**: prosopite todoに記録されてるテストだけ実施して、prosopite todoを更新するコマンドを追加して欲しい
- **採用アプローチ**: 
  - TodoFileから記録されているtest_locationsを抽出し、それらのテストのみを実行する新規Rakeタスク `prosopite_todo:run` を実装
  - `PROSOPITE_TODO_UPDATE=1` 環境変数を設定してRSpecを実行することで、テスト後に自動的にTODOファイルが更新される
  - test_locationsはSetで管理されているため重複は自動排除
  - **セキュリティ対策**: `system` の配列形式を使用し、シェルインジェクション脆弱性を防止
  - **エラーハンドリング**: テスト失敗時の終了ステータスを処理し、失敗メッセージを出力

## Changes
- `lib/prosopite_todo/task_helpers.rb`: `run` メソッドを追加
  - TODOファイルからtest_locationsを取得
  - `system` の配列形式でRSpecを安全に実行（シェルインジェクション対策）
  - テスト結果の終了ステータスを返却
- `lib/prosopite_todo/tasks.rb`: `prosopite_todo:run` Rakeタスクを追加
- `spec/prosopite_todo/rake_tasks_spec.rb`: `run` メソッドのテストを追加
  - 空のテスト位置の処理
  - 複数テストの実行
  - 重複排除
  - テスト失敗時の動作
  - スペース含みパスの安全な処理

## Verification
- [x] RSpec テスト (246 examples, 0 failures)
- [x] シェルインジェクション対策のテスト
- [ ] 実際のプロジェクトでの動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)